### PR TITLE
README.md: Full Revamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 ### **Flatpak:**
 
-<a href='https://flathub.org/apps/org.gimp.GIMP'><img width='240' alt='Download on Flathub' src='https://dl.flathub.org/assets/badges/flathub-badge-en.png'/></a>
+<a href='https://flathub.org/apps/io.github.amit9838.weather'><img width='240' alt='Download on Flathub' src='https://dl.flathub.org/assets/badges/flathub-badge-en.png'/></a>
 
 * Or you can use the terminal:
 ```
@@ -27,6 +27,10 @@ flatpak install flathub io.github.amit9838.weather
 ```
 
 ### Snap (Unofficial):
+
+<a href='https://snapcraft.io/mousam'><img width='240' alt='Download on SnapCraft' src='https://github.com/snapcore/snap-store-badges/blob/master/EN/%5BEN%5D-snap-store-black-uneditable.png?raw=true'/></a>
+
+* Or you can use the terminal:
 
 ```
 sudo snap install mousam

--- a/README.md
+++ b/README.md
@@ -1,18 +1,63 @@
-# weather
+<div align="center">
+<img src="https://github.com/amit9838/weather/blob/master/data/icons/hicolor/scalable/apps/io.github.amit9838.weather.png?raw=true" width="80">
+<h1>Weather</h1>
+<p>Beautiful lightweight weather app.</p>
+<img src="https://img.shields.io/github/v/release/amit9838/weather?style=flat&label=Latest+Release&color=%234a92ff">
+</div>
+<div align="center">
+<img src="https://github.com/amit9838/weather/blob/master/screenshots/ss2-haze_night.png?raw=true#gh-dark-mode-only">
+<img src="https://github.com/amit9838/weather/blob/master/screenshots/ss1-overcast_clouds_day.png?raw=true#gh-light-mode-only">
+</div>
 
-Beautiful lightweight weather app.
-
+## Features
+* See weather with dynamically changing gradient-based background according current weather conditions
+* See today, tomorrow and 5-day forcasts
+* See conditions in metric or imperial systems
+* Option to use Personal API Key
 
 ## Installation
 
-Flatpak:
+### **Flatpak:**
 
+<a href='https://flathub.org/apps/org.gimp.GIMP'><img width='240' alt='Download on Flathub' src='https://dl.flathub.org/assets/badges/flathub-badge-en.png'/></a>
+
+* Or you can use the terminal:
 ```
-flatpak install io.github.amit9838.weather
+flatpak install flathub io.github.amit9838.weather
 ```
 
-Snap(Unofficial):
+### Snap (Unofficial):
 
 ```
 sudo snap install mousam
 ```
+
+## Build
+### Dependances
+* python3-requests
+* build-essential
+* meson
+  
+### Build
+```
+meson build
+ninja -C build
+```
+
+### Install
+```
+sudo ninja -C build install
+```
+### Run
+```
+weather
+```
+
+## Thanks to:
+* [@amit9838](https://github.com/amit9838)
+* [@sabriunal](https://github.com/sabriunal)
+* [@soumyaDghosh](https://github.com/soumyaDghosh)
+* [@vorons](https://github.com/vorons)
+* [@GabsEdits](https://github.com/GabsEdits)
+
+Total contributors: 5


### PR DESCRIPTION
* It will close https://github.com/amit9838/weather/issues/9
* It looks modern and in the GNOME Ecosystem
* Screenshot supports Light & Dark Mode, so if the user has Dark Mode, he will see the dark mode screenshot, if he as Light Mode he will see light mode screenshot of the app.

**Example:**
* Dark Mode:
![image](https://github.com/amit9838/weather/assets/110247388/165b9525-91e0-4b9b-9ed6-03c0008912b5)
* Light Mode
![image](https://github.com/amit9838/weather/assets/110247388/125eea2f-9bb5-4f58-b923-9aff3e885ca2)
